### PR TITLE
Fix dots position in api 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ dependencies {
 | Attribute | Description |
 | --- | --- |
 | `dotsColor` | Color of the indicator dot |
-| `dotsColor` | Color of the stroke dots (by default the indicator color) |
+| `dotsStrokeColor` | Color of the stroke dots (by default the indicator color) |
 | `dotsSize` | Size in dp of the dots (by default 16dp) |
 | `dotsSpacing` | Size in dp of the space between the dots (by default 4dp) |
 | `dotsCornerRadius` | The dots corner radius (by default the half of dotsSize for circularity) |
@@ -145,7 +145,7 @@ dependencies {
 | Attribute | Description |
 | --- | --- |
 | `dotsColor` | Color of the indicator dot |
-| `dotsColor` | Color of the stroke dots (by default the indicator color) |
+| `dotsStrokeColor` | Color of the stroke dots (by default the indicator color) |
 | `dotsSize` | Size in dp of the dots (by default 16dp) |
 | `dotsSpacing` | Size in dp of the space between the dots (by default 4dp) |
 | `dotsCornerRadius` | The dots corner radius (by default the half of dotsSize for circularity) |

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ buildscript {
 
 allprojects {
   repositories {
+    maven {
+      url "https://maven.google.com"
+    }
     google()
     jcenter()
   }

--- a/viewpagerdotsindicator-sample/build.gradle
+++ b/viewpagerdotsindicator-sample/build.gradle
@@ -4,7 +4,7 @@ android {
   compileSdkVersion 28
   defaultConfig {
     applicationId "com.tbuonomo.dotsindicatorsample"
-    minSdkVersion 19
+    minSdkVersion 17
     targetSdkVersion 28
     versionCode 1
     versionName "1.0"

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.java
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.java
@@ -13,7 +13,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -121,7 +120,7 @@ public class DotsIndicator extends LinearLayout {
     for (int i = 0; i < count; i++) {
       View dot = LayoutInflater.from(getContext()).inflate(R.layout.dot_layout, this, false);
       ImageView imageView = dot.findViewById(R.id.dot);
-      RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) imageView.getLayoutParams();
+      LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) imageView.getLayoutParams();
       params.width = params.height = (int) dotsSize;
       params.setMargins((int) dotsSpacing, 0, (int) dotsSpacing, 0);
       DotsGradientDrawable background = new DotsGradientDrawable();

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/SpringDotsIndicator.java
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/SpringDotsIndicator.java
@@ -16,7 +16,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -170,9 +169,8 @@ public class SpringDotsIndicator extends FrameLayout {
     ImageView dotView = dot.findViewById(R.id.spring_dot);
     dotView.setBackground(
         ContextCompat.getDrawable(getContext(), stroke ? R.drawable.spring_dot_stroke_background : R.drawable.spring_dot_background));
-    RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) dotView.getLayoutParams();
+    LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) dotView.getLayoutParams();
     params.width = params.height = stroke ? dotsStrokeSize : dotIndicatorSize;
-    params.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
 
     params.setMargins(dotsSpacing, 0, dotsSpacing, 0);
 

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/WormDotsIndicator.java
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/WormDotsIndicator.java
@@ -17,7 +17,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -176,9 +175,8 @@ public class WormDotsIndicator extends FrameLayout {
     View dotImageView = dot.findViewById(R.id.worm_dot);
     dotImageView.setBackground(
         ContextCompat.getDrawable(getContext(), stroke ? R.drawable.worm_dot_stroke_background : R.drawable.worm_dot_background));
-    RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) dotImageView.getLayoutParams();
+    LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) dotImageView.getLayoutParams();
     params.width = params.height = dotsSize;
-    params.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
 
     params.setMargins(dotsSpacing, 0, dotsSpacing, 0);
 

--- a/viewpagerdotsindicator/src/main/res/layout/dot_layout.xml
+++ b/viewpagerdotsindicator/src/main/res/layout/dot_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
@@ -13,4 +13,4 @@
       android:background="@drawable/dot_background"
       />
 
-</RelativeLayout>
+</LinearLayout>

--- a/viewpagerdotsindicator/src/main/res/layout/spring_dot_layout.xml
+++ b/viewpagerdotsindicator/src/main/res/layout/spring_dot_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
@@ -13,4 +13,4 @@
       android:background="@drawable/spring_dot_background"
       />
 
-</RelativeLayout>
+</LinearLayout>

--- a/viewpagerdotsindicator/src/main/res/layout/worm_dot_layout.xml
+++ b/viewpagerdotsindicator/src/main/res/layout/worm_dot_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
@@ -13,4 +13,4 @@
       android:background="@drawable/worm_dot_background"
       />
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
1. Fix readme custom attributes
2. Fix 'ERROR: Failed to resolve: support-dynamic-animation' when Sync gradle
3. Fix dots position in api 17 and 18
<img width="1003" alt="Screen Shot 2019-04-26 at 6 23 24 PM" src="https://user-images.githubusercontent.com/22843329/56815216-02811180-6856-11e9-8035-13b4d654ae70.png">
this bug happened because of `RelativeLayout` right margin. I don't know why but in api 17 and 18 `params.setMargins(dotsSpacing, 0, dotsSpacing, 0);` only left margin work. I use `setMarginStart` and `setMarginEnd` but nothing change then I change `RelativeLayout` to `LinearLayout`after that every thing is ok in both above api 18 and below that.
<img width="1009" alt="Screen Shot 2019-04-26 at 6 30 55 PM" src="https://user-images.githubusercontent.com/22843329/56815620-111bf880-6857-11e9-9f17-e6ea5b2b71fb.png">

