### PR TITLE
Fix a couple of problems when the number of pages change

### DIFF
--- a/viewpagerdotsindicator-sample/src/main/java/com/tbuonomo/dotsindicatorsample/viewpager2/DotIndicatorPager2Adapter.kt
+++ b/viewpagerdotsindicator-sample/src/main/java/com/tbuonomo/dotsindicatorsample/viewpager2/DotIndicatorPager2Adapter.kt
@@ -7,15 +7,20 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.tbuonomo.dotsindicatorsample.R
 
 class DotIndicatorPager2Adapter : RecyclerView.Adapter<ViewHolder>() {
-
+  var count = 10
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
     return object : ViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.material_page, parent, false)) {}
   }
 
-  override fun getItemCount() = 10
+  override fun getItemCount() = count
 
   override fun onBindViewHolder(holder: ViewHolder, position: Int) {
     // Empty
+  }
+
+  fun refresh() {
+    count = (1+Math.random()*10).toInt()
+    notifyDataSetChanged()
   }
 }

--- a/viewpagerdotsindicator-sample/src/main/java/com/tbuonomo/dotsindicatorsample/viewpager2/ViewPager2Activity.kt
+++ b/viewpagerdotsindicator-sample/src/main/java/com/tbuonomo/dotsindicatorsample/viewpager2/ViewPager2Activity.kt
@@ -1,6 +1,7 @@
 package com.tbuonomo.dotsindicatorsample.viewpager2
 
 import android.os.Bundle
+import android.view.View
 import android.view.Window
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
@@ -13,6 +14,11 @@ import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
 
 class ViewPager2Activity : AppCompatActivity() {
 
+  val adapter by lazy { DotIndicatorPager2Adapter() }
+  val dotsIndicator by lazy { findViewById<DotsIndicator>(R.id.dots_indicator) }
+  val springDotsIndicator by lazy { findViewById<SpringDotsIndicator>(R.id.spring_dots_indicator) }
+  val wormDotsIndicator by lazy { findViewById<WormDotsIndicator>(R.id.worm_dots_indicator) }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     requestWindowFeature(Window.FEATURE_NO_TITLE)
@@ -20,12 +26,7 @@ class ViewPager2Activity : AppCompatActivity() {
             WindowManager.LayoutParams.FLAG_FULLSCREEN)
     setContentView(R.layout.activity_view_pager2)
 
-    val dotsIndicator = findViewById<DotsIndicator>(R.id.dots_indicator)
-    val springDotsIndicator = findViewById<SpringDotsIndicator>(R.id.spring_dots_indicator)
-    val wormDotsIndicator = findViewById<WormDotsIndicator>(R.id.worm_dots_indicator)
-
     val viewPager2 = findViewById<ViewPager2>(R.id.view_pager2)
-    val adapter = DotIndicatorPager2Adapter()
     viewPager2.adapter = adapter
 
     val zoomOutPageTransformer = ZoomOutPageTransformer()
@@ -37,4 +38,13 @@ class ViewPager2Activity : AppCompatActivity() {
     springDotsIndicator.setViewPager2(viewPager2)
     wormDotsIndicator.setViewPager2(viewPager2)
   }
+
+
+  fun refresh(view: View) {
+    adapter.refresh()
+    dotsIndicator.refreshDots()
+    springDotsIndicator.refreshDots()
+    wormDotsIndicator.refreshDots()
+  }
+
 }

--- a/viewpagerdotsindicator-sample/src/main/res/layout/activity_view_pager2.xml
+++ b/viewpagerdotsindicator-sample/src/main/res/layout/activity_view_pager2.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/background_main"
-    tools:context="com.tbuonomo.dotsindicatorsample.viewpager.ViewPagerActivity"
+    tools:context="com.tbuonomo.dotsindicatorsample.viewpager2.ViewPager2Activity"
     >
 
   <TextView
@@ -85,6 +85,16 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/spring_dots_indicator"
       ></com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator>
+
+  <Button
+      android:text="REFRESH"
+      android:onClick="refresh"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -105,6 +105,13 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
     } else if (dots.size > pager!!.count) {
       removeDots(dots.size - pager!!.count)
     }
+    with(pager) {
+      if (this!=null){
+        if (currentItem > count) {
+          setCurrentItem(count,false)
+        }
+      }
+    }
   }
 
   protected fun refreshDotsColors() {

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -140,7 +140,7 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
     }
   }
 
-  protected fun refreshDots() {
+  fun refreshDots() {
     if (pager == null) {
       return
     }

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.kt
@@ -138,8 +138,10 @@ class DotsIndicator @JvmOverloads constructor(context: Context, attrs: Attribute
       }
 
       override fun resetPosition(position: Int) {
-        dots[position].setWidth(dotsSize.toInt())
-        refreshDotColor(position)
+        if (position<dots.size) {
+          dots[position].setWidth(dotsSize.toInt())
+          refreshDotColor(position)
+        }
       }
 
       override val pageCount: Int


### PR DESCRIPTION
One of the things that ViewPager2 does for us is do a better job of keeping track of changes to Fragments when the underlying Adapter changes. Without adding a lot of code, I was unable to reproduce this in the included test app, but was able to test on my app. The included changes work for my use case, but I could not test every scenario.