### PR TITLE
As a library user I want to set custom pager

### DIFF
--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -83,7 +83,7 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
   }
 
   var pager: Pager? = null
-    set(value) { 
+    set(value) {
       field = value
       refreshDots()
     }

--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -83,6 +83,10 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
   }
 
   var pager: Pager? = null
+    set(value) { 
+      field = value
+      refreshDots()
+    }
 
   interface Pager {
     val isNotEmpty: Boolean
@@ -227,8 +231,6 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
         viewPager.addOnPageChangeListener(onPageChangeListener!!)
       }
     }
-
-    refreshDots()
   }
 
   fun setViewPager2(viewPager2: ViewPager2) {
@@ -277,8 +279,6 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
         viewPager2.registerOnPageChangeCallback(onPageChangeCallback!!)
       }
     }
-
-    refreshDots()
   }
 
   // EXTENSIONS


### PR DESCRIPTION
I display 5 questions in view pager with dots at the bottom. User answers questions, and pager automatically scrolls to the next question. User can swipe left to see already answered questions, but he **can not** swipe forward.

The easiest way to disable scrolling forward is to not to add next questions to view pager adapter.
I have page adapter with 2 items, but I want 5 dots. I achieved it using custom implementation of `BaseDotsIndicator.Pager`.

In the scope of this PR I want you to let library users set their own pager to the library.