### PR TITLE
added listeners to viewpager2 adapter

### DIFF
--- a/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/java/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -249,6 +249,31 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(context: Context,
         super.onChanged()
         refreshDots()
       }
+
+      override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+        super.onItemRangeChanged(positionStart, itemCount)
+        refreshDots()
+      }
+
+      override fun onItemRangeChanged(positionStart: Int, itemCount: Int, payload: Any?) {
+        super.onItemRangeChanged(positionStart, itemCount, payload)
+        refreshDots()
+      }
+
+      override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+        super.onItemRangeInserted(positionStart, itemCount)
+        refreshDots()
+      }
+
+      override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+        super.onItemRangeRemoved(positionStart, itemCount)
+        refreshDots()
+      }
+
+      override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
+        super.onItemRangeMoved(fromPosition, toPosition, itemCount)
+        refreshDots()
+      }
     })
 
     pager = object : Pager {


### PR DESCRIPTION
Fixing this issue
https://github.com/tommybuonomo/dotsindicator/issues/131

As the documentation state, using `AdapterDataObserver` we should listen to all changes.
Using only `onChanged` will trigger only when using `notifyDataSetChanged`, but if you're using any of the specific methods like `notifyItemChanged` it won't be triggered. 
So in this PR I fix it by simply listening to all changes and call `refreshDots` from each one