### PR TITLE
Remove app_name from resources

### DIFF
--- a/viewpagerdotsindicator/src/main/res/values/strings.xml
+++ b/viewpagerdotsindicator/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">View Pager Dots Indicator</string>
 </resources>


### PR DESCRIPTION
This resources is exported to consumers meaning that they will have a resources call `app_name` with the value "View Pager Dots Indicator"
