### PR TITLE
Use the LTS

### DIFF
--- a/viewpagerdotsindicator/build.gradle.kts
+++ b/viewpagerdotsindicator/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(18)
+    jvmToolchain(17)
 }
 
 dependencies {


### PR DESCRIPTION
When using the version 5.0 we are getting this message error:

> .../transformed/dotsindicator-5.0-release-api.jar(/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.class): major version 62 is newer than 61, the highest major version supported by this compiler.
  It is recommended that the compiler be upgraded.
> .../transformed/dotsindicator-5.0-release-api.jar(/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.class): major version 62 is newer than 61, the highest major version supported by this compiler.
  It is recommended that the compiler be upgraded.

We could upgrade our version to avoid that issue but we would like to use the LTS to be more safe and I think that this library doesn't need anything special from java 18. That's the reason of this change.

(Sorry for the change in the end of line, I used the github edit to make this change and it added that change automatically...)