### PR TITLE
Upgraded the AGP to 8.2.2 and Gradle to 8.2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 const val kotlinVersion = "1.8.10"
 
 object BuildPlugins {
-    val gradlePlugin = "com.android.tools.build:gradle:8.1.0-beta02"
+    val gradlePlugin = "com.android.tools.build:gradle:8.2.2"
     val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 10 20:33:42 CET 2023
+#Mon Feb 19 00:22:19 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I am currently using this Android Studio Version 
```

Android Studio Hedgehog | 2023.1.1 Patch 2
Build #AI-231.9392.1.2311.11330709, built on January 19, 2024
Runtime version: 17.0.7+0-17.0.7b1000.6-10550314 aarch64
```
and I was getting these error on running the application 

<img width="1415" alt="Screenshot 2024-02-19 at 00 00 57" src="https://github.com/tommybuonomo/dotsindicator/assets/23280743/90612e31-e0f6-4d9e-9ef9-5203f119d81b">

<img width="1416" alt="Screenshot 2024-02-19 at 00 01 20" src="https://github.com/tommybuonomo/dotsindicator/assets/23280743/b337412a-543c-4bb9-aed9-ec0589f9704c">


So I updated these according the Android Studio Version and I have run through the app and it works fine. Below is the screenshot of the running mobile application.

<img width="299" alt="Screenshot 2024-02-19 at 00 24 27" src="https://github.com/tommybuonomo/dotsindicator/assets/23280743/ee4abd80-d539-41cf-9432-d61010dd92d1">


