### PR TITLE
ci: add GitHub Actions workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns: [ "*" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      kotlin:
+        patterns: [ "org.jetbrains.kotlin*" ]
+      agp:
+        patterns: [ "com.android.tools.build*" ]
+      compose:
+        patterns: [ "androidx.compose*" ]
+      androidx:
+        patterns: [ "androidx.*" ]
+      publishing:
+        patterns:
+          - "com.vanniktech*"
+          - "com.gradleup.nmcp*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build library
+        run: ./gradlew :viewpagerdotsindicator:assembleRelease
+
+      - name: Run Android Lint
+        run: ./gradlew :viewpagerdotsindicator:lint
+
+      - name: Upload lint results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results
+          path: viewpagerdotsindicator/build/reports/lint-results*.html
+          retention-days: 7


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/ci.yml`): déclenché sur chaque PR et push vers `master`
  - Build release de la librairie (`:viewpagerdotsindicator:assembleRelease`)
  - Android Lint sur le module librairie
  - Upload du rapport Lint en artifact (7 jours de rétention)
  - Annulation automatique des runs concurrents sur la même branche
  - Gradle build cache via `gradle/actions/setup-gradle@v4`
- **Dependabot** (`.github/dependabot.yml`): mises à jour hebdomadaires (lundi), groupées par écosystème
  - `github-actions` : toutes les actions en un seul groupe
  - `gradle` : 5 groupes séparés — Kotlin, AGP, Compose, AndroidX, plugins de publication

## Test plan

- [ ] Vérifier que le workflow CI se déclenche correctement sur cette PR
- [ ] Vérifier que le build et le lint passent sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)