### PR TITLE
fix: resolve RTL crashes, RTL reset bug, and fast-scroll color glitch

### DIFF
--- a/viewpagerdotsindicator-sample/build.gradle.kts
+++ b/viewpagerdotsindicator-sample/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/viewpagerdotsindicator/build.gradle.kts
+++ b/viewpagerdotsindicator/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/BaseDotsIndicator.kt
@@ -214,10 +214,22 @@ abstract class BaseDotsIndicator @JvmOverloads constructor(
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
-        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1 && layoutDirection == View.LAYOUT_DIRECTION_RTL) {
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            rotation = 180f
-            requestLayout()
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
+            when {
+                layoutDirection == View.LAYOUT_DIRECTION_RTL -> {
+                    layoutDirection = View.LAYOUT_DIRECTION_LTR
+                    rotation = 180f
+                    requestLayout()
+                }
+                rotation == 180f -> {
+                    val parentIsRtl = (parent as? View)?.layoutDirection == View.LAYOUT_DIRECTION_RTL
+                    if (!parentIsRtl) {
+                        layoutDirection = View.LAYOUT_DIRECTION_INHERIT
+                        rotation = 0f
+                        requestLayout()
+                    }
+                }
+            }
         }
     }
 

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/DotsIndicator.kt
@@ -163,7 +163,11 @@ class DotsIndicator @JvmOverloads constructor(
 
             override fun resetPosition(position: Int) {
                 dots[position].setWidth(dotsSize.toInt())
-                refreshDotColor(position)
+                val elevationItem = dots[position]
+                val background = elevationItem.background as? DotsGradientDrawable ?: return
+                background.setColor(dotsColor)
+                elevationItem.setBackgroundCompat(background)
+                elevationItem.invalidate()
             }
 
             override val pageCount: Int

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/WormDotsIndicator.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/WormDotsIndicator.kt
@@ -189,8 +189,8 @@ class WormDotsIndicator @JvmOverloads constructor(
                         widthFinalPosition = dotsSize
                     }
                     in 0.1f..0.9f -> {
-                        xFinalPosition = x
-                        widthFinalPosition = nextX - x + dotsSize
+                        xFinalPosition = minOf(x, nextX)
+                        widthFinalPosition = kotlin.math.abs(nextX - x) + dotsSize
                     }
                     else -> {
                         xFinalPosition = nextX

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/SpringIndicatorType.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/SpringIndicatorType.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.tbuonomo.viewpagerdotsindicator.compose.Dot
 import com.tbuonomo.viewpagerdotsindicator.compose.model.DotGraphic
@@ -27,60 +29,67 @@ class SpringIndicatorType(
         dotSpacing: Dp,
         onDotClicked: ((Int) -> Unit)?,
     ) {
+        val parentLayoutDirection = LocalLayoutDirection.current
         var firstDotPositionX: Float by remember(dotCount, dotsGraphic) { mutableStateOf(-1f) }
         var lastDotPositionX: Float by remember(dotCount, dotsGraphic) { mutableStateOf(-1f) }
-        Box(modifier = modifier) {
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth(), content = {
-                    items(dotCount) { dotIndex ->
-                        val dotModifier = when (dotIndex) {
-                            0 -> {
-                                Modifier.onGloballyPositioned {
-                                    firstDotPositionX = it.positionInParent().x
+        // Force LTR on the outer Box so that absoluteOffset uses physical left-to-right coordinates.
+        // The LazyRow restores the original direction to keep item order correct in RTL.
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Box(modifier = modifier) {
+                CompositionLocalProvider(LocalLayoutDirection provides parentLayoutDirection) {
+                    LazyRow(
+                        modifier = Modifier
+                            .fillMaxWidth(), content = {
+                            items(dotCount) { dotIndex ->
+                                val dotModifier = when (dotIndex) {
+                                    0 -> {
+                                        Modifier.onGloballyPositioned {
+                                            firstDotPositionX = it.positionInParent().x
+                                        }
+                                    }
+                                    dotCount - 1 -> {
+                                        Modifier.onGloballyPositioned {
+                                            lastDotPositionX = it.positionInParent().x
+                                        }
+                                    }
+                                    else -> Modifier
                                 }
+                                Dot(dotsGraphic, dotModifier.clickable {
+                                    onDotClicked?.invoke(dotIndex)
+                                })
                             }
-                            dotCount - 1 -> {
-                                Modifier.onGloballyPositioned {
-                                    lastDotPositionX = it.positionInParent().x
-                                }
-                            }
-                            else -> Modifier
-                        }
-                        Dot(dotsGraphic, dotModifier.clickable {
-                            onDotClicked?.invoke(dotIndex)
-                        })
-                    }
-                }, horizontalArrangement = Arrangement.spacedBy(
-                    dotSpacing, alignment = Alignment.CenterHorizontally
-                ),
-                contentPadding = PaddingValues(start = dotSpacing, end = dotSpacing)
-            )
-            if (firstDotPositionX != -1f && lastDotPositionX != -1f) {
-                val centeredOffset by remember {
-                    derivedStateOf {
-                        (dotsGraphic.size - selectorDotGraphic.size) / 2
-                    }
-                }
-                val density = LocalDensity.current.density
-                val foregroundDotPositionDp by remember(globalOffsetProvider) {
-                    derivedStateOf {
-                        computeSelectorDotPositionDp(
-                            firstDotPositionX,
-                            lastDotPositionX,
-                            dotCount,
-                            globalOffsetProvider(),
-                            density,
-                            centeredOffset
-                        )
-                    }
-                }
-                Dot(
-                    selectorDotGraphic, Modifier.offset(
-                        x = foregroundDotPositionDp,
-                        y = centeredOffset
+                        }, horizontalArrangement = Arrangement.spacedBy(
+                            dotSpacing, alignment = Alignment.CenterHorizontally
+                        ),
+                        contentPadding = PaddingValues(start = dotSpacing, end = dotSpacing)
                     )
-                )
+                }
+                if (firstDotPositionX != -1f && lastDotPositionX != -1f) {
+                    val centeredOffset by remember {
+                        derivedStateOf {
+                            (dotsGraphic.size - selectorDotGraphic.size) / 2
+                        }
+                    }
+                    val density = LocalDensity.current.density
+                    val foregroundDotPositionDp by remember(globalOffsetProvider) {
+                        derivedStateOf {
+                            computeSelectorDotPositionDp(
+                                firstDotPositionX,
+                                lastDotPositionX,
+                                dotCount,
+                                globalOffsetProvider(),
+                                density,
+                                centeredOffset
+                            )
+                        }
+                    }
+                    Dot(
+                        selectorDotGraphic, Modifier.absoluteOffset(
+                            x = foregroundDotPositionDp,
+                            y = centeredOffset
+                        )
+                    )
+                }
             }
         }
     }

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/WormIndicatorType.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/WormIndicatorType.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.tbuonomo.viewpagerdotsindicator.compose.Dot
 import com.tbuonomo.viewpagerdotsindicator.compose.model.DotGraphic
+import kotlin.math.abs
 import kotlin.math.floor
 
 class WormIndicatorType(
@@ -66,7 +67,7 @@ class WormIndicatorType(
                 val density = LocalDensity.current.density
                 val distanceBetween2DotsDp by remember {
                     derivedStateOf {
-                        (((lastDotPositionX - firstDotPositionX) / (dotCount - 1)) / density).dp
+                        ((abs(lastDotPositionX - firstDotPositionX) / (dotCount - 1)) / density).dp
                     }
                 }
                 val selectorDotWidthDp by remember(lastDotPositionX, firstDotPositionX) {

--- a/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/WormIndicatorType.kt
+++ b/viewpagerdotsindicator/src/main/kotlin/com/tbuonomo/viewpagerdotsindicator/compose/type/WormIndicatorType.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.tbuonomo.viewpagerdotsindicator.compose.Dot
 import com.tbuonomo.viewpagerdotsindicator.compose.model.DotGraphic
@@ -29,80 +31,97 @@ class WormIndicatorType(
         dotSpacing: Dp,
         onDotClicked: ((Int) -> Unit)?,
     ) {
+        val parentLayoutDirection = LocalLayoutDirection.current
+        val isRtl = parentLayoutDirection == LayoutDirection.Rtl
         var firstDotPositionX: Float by remember(dotCount) { mutableStateOf(-1f) }
         var lastDotPositionX: Float by remember(dotCount) { mutableStateOf(-1f) }
-        Box(modifier = modifier) {
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth(), content = {
-                    items(dotCount) { dotIndex ->
-                        val dotModifier = when (dotIndex) {
-                            0 -> {
-                                Modifier.onGloballyPositioned {
-                                    firstDotPositionX = it.positionInParent().x
+        // Force LTR on the outer Box so that absoluteOffset uses physical left-to-right coordinates.
+        // The LazyRow restores the original direction to keep item order correct in RTL.
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Box(modifier = modifier) {
+                CompositionLocalProvider(LocalLayoutDirection provides parentLayoutDirection) {
+                    LazyRow(
+                        modifier = Modifier
+                            .fillMaxWidth(), content = {
+                            items(dotCount) { dotIndex ->
+                                val dotModifier = when (dotIndex) {
+                                    0 -> {
+                                        Modifier.onGloballyPositioned {
+                                            firstDotPositionX = it.positionInParent().x
+                                        }
+                                    }
+                                    dotCount - 1 -> {
+                                        Modifier.onGloballyPositioned {
+                                            lastDotPositionX = it.positionInParent().x
+                                        }
+                                    }
+                                    else -> Modifier
                                 }
+                                Dot(dotsGraphic, dotModifier.clickable {
+                                    onDotClicked?.invoke(dotIndex)
+                                })
                             }
-                            dotCount - 1 -> {
-                                Modifier.onGloballyPositioned {
-                                    lastDotPositionX = it.positionInParent().x
-                                }
-                            }
-                            else -> Modifier
+                        }, horizontalArrangement = Arrangement.spacedBy(
+                            dotSpacing, alignment = Alignment.CenterHorizontally
+                        ),
+                        contentPadding = PaddingValues(start = dotSpacing, end = dotSpacing)
+                    )
+                }
+                if (firstDotPositionX != -1f && lastDotPositionX != -1f) {
+                    val centeredOffset by remember {
+                        derivedStateOf {
+                            (dotsGraphic.size - wormDotGraphic.size) / 2
                         }
-                        Dot(dotsGraphic, dotModifier.clickable {
-                            onDotClicked?.invoke(dotIndex)
-                        })
                     }
-                }, horizontalArrangement = Arrangement.spacedBy(
-                    dotSpacing, alignment = Alignment.CenterHorizontally
-                ),
-                contentPadding = PaddingValues(start = dotSpacing, end = dotSpacing)
-            )
-            if (firstDotPositionX != -1f && lastDotPositionX != -1f) {
-                val centeredOffset by remember {
-                    derivedStateOf {
-                        (dotsGraphic.size - wormDotGraphic.size) / 2
+                    val density = LocalDensity.current.density
+                    val distanceBetween2DotsDp by remember {
+                        derivedStateOf {
+                            ((abs(lastDotPositionX - firstDotPositionX) / (dotCount - 1)) / density).dp
+                        }
                     }
-                }
-                val density = LocalDensity.current.density
-                val distanceBetween2DotsDp by remember {
-                    derivedStateOf {
-                        ((abs(lastDotPositionX - firstDotPositionX) / (dotCount - 1)) / density).dp
+                    val signedDistanceBetween2DotsDp by remember {
+                        derivedStateOf {
+                            (((lastDotPositionX - firstDotPositionX) / (dotCount - 1)) / density).dp
+                        }
                     }
-                }
-                val selectorDotWidthDp by remember(lastDotPositionX, firstDotPositionX) {
-                    derivedStateOf {
-                        distanceBetween2DotsDp + wormDotGraphic.size
+                    val selectorDotWidthDp by remember(lastDotPositionX, firstDotPositionX) {
+                        derivedStateOf {
+                            distanceBetween2DotsDp + wormDotGraphic.size
+                        }
                     }
-                }
-                val paddingStartAndEnd: Pair<Dp, Dp> by remember(globalOffsetProvider()) {
-                    derivedStateOf {
-                        val endPaddingOffset = 1f - ((globalOffsetProvider() % 1.0f) * 2f).coerceIn(0f, 1f)
-                        val startPaddingOffset = ((globalOffsetProvider() % 1.0f - 0.5f) * 2f).coerceIn(0f, 1f)
-                        val startPadding = distanceBetween2DotsDp * startPaddingOffset
-                        val endPadding = distanceBetween2DotsDp * endPaddingOffset
-                        startPadding to endPadding
+                    val paddingStartAndEnd: Pair<Dp, Dp> by remember(globalOffsetProvider()) {
+                        derivedStateOf {
+                            val endPaddingOffset = 1f - ((globalOffsetProvider() % 1.0f) * 2f).coerceIn(0f, 1f)
+                            val startPaddingOffset = ((globalOffsetProvider() % 1.0f - 0.5f) * 2f).coerceIn(0f, 1f)
+                            val startPadding = distanceBetween2DotsDp * startPaddingOffset
+                            val endPadding = distanceBetween2DotsDp * endPaddingOffset
+                            startPadding to endPadding
+                        }
                     }
-                }
-                val foregroundDotOffsetDp by remember(globalOffsetProvider) {
-                    derivedStateOf {
-                        val foregroundDotPositionX =
-                            firstDotPositionX + (lastDotPositionX - firstDotPositionX) / (dotCount - 1) * floor(
-                                globalOffsetProvider().toDouble()
+                    // In RTL the worm expands toward the left (physical), so start/end padding roles swap.
+                    val effectivePaddingStart = if (isRtl) paddingStartAndEnd.second else paddingStartAndEnd.first
+                    val effectivePaddingEnd = if (isRtl) paddingStartAndEnd.first else paddingStartAndEnd.second
+                    val foregroundDotOffsetDp by remember(globalOffsetProvider) {
+                        derivedStateOf {
+                            val foregroundDotPositionX =
+                                firstDotPositionX + (lastDotPositionX - firstDotPositionX) / (dotCount - 1) * floor(
+                                    globalOffsetProvider().toDouble()
+                                )
+                            // Shift anchor left by one step in RTL so the box spans from dot P+1 to dot P.
+                            (foregroundDotPositionX / density).dp + centeredOffset + minOf(0.dp, signedDistanceBetween2DotsDp)
+                        }
+                    }
+                    Dot(
+                        wormDotGraphic,
+                        Modifier
+                            .absoluteOffset(
+                                x = foregroundDotOffsetDp,
+                                y = centeredOffset
                             )
-                        (foregroundDotPositionX / density).dp + centeredOffset
-                    }
+                            .width(selectorDotWidthDp)
+                            .padding(start = effectivePaddingStart, end = effectivePaddingEnd)
+                    )
                 }
-                Dot(
-                    wormDotGraphic,
-                    Modifier
-                        .offset(
-                            x = foregroundDotOffsetDp,
-                            y = centeredOffset
-                        )
-                        .width(selectorDotWidthDp)
-                        .padding(start = paddingStartAndEnd.first, end = paddingStartAndEnd.second)
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary

- **#207 — RTL crash in WormDotsIndicator**: When RTL layout direction was active, `nextX - x + dotsSize` produced a negative width, causing `IllegalArgumentException: Padding must be non-negative` in the spring animation. Fixed by using `abs(nextX - x) + dotsSize` and `minOf(x, nextX)` for the x position.
- **#209 — RTL state not reset on LTR switch**: Once `layoutDirection` was explicitly forced to LTR (as part of the RTL-via-rotation workaround), the view had no way to detect when the parent returned to LTR. Added a second `when` branch that resets `rotation = 0f` and restores `layoutDirection = INHERIT` when the parent is no longer RTL.
- **#211 — Dot color stuck after fast scroll**: `resetPosition()` called `refreshDotColor()`, which depends on `pager.currentItem`. During a fast fling, `currentItem` already points to the final page while intermediate dots are still being reset, causing incorrect colors to stick. Fixed by directly setting `dotsColor` in `resetPosition()`.
- **Housekeeping**: bump JVM toolchain from 17 to 21 in both modules.

## Test plan

- [ ] Enable RTL in Android Developer Settings → open sample → swipe ViewPager with WormDotsIndicator → no crash
- [ ] With RTL active, disable RTL → confirm indicator rotates back to normal without restarting the activity
- [ ] Fast-fling a ViewPager with DotsIndicator → confirm all unselected dots return to their default color
- [ ] Verify standard LTR behavior is unchanged for all three indicator types

🤖 Generated with [Claude Code](https://claude.com/claude-code)